### PR TITLE
Sample config file for ESP8266

### DIFF
--- a/opentherm.h
+++ b/opentherm.h
@@ -21,8 +21,10 @@ namespace opentherm {
 enum OpenThermResponseStatus {
 NONE,
 SUCCESS,
-INVALID,
-TIMEOUT
+TIMEOUT,
+INVSTART,
+INVPARITY,
+INVMSGTYPE,
 };
 
 

--- a/opentherm_esp8266.yaml
+++ b/opentherm_esp8266.yaml
@@ -1,0 +1,66 @@
+esphome:
+  includes:
+    - opentherm.h
+    - opentherm.cpp
+    - opentherm_gw_climate.h
+    - opentherm_gw_climate.cpp
+  name: opentherm_gateway
+  platform: ESP8266
+  board: d1_mini
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+
+# Enable logging
+logger:
+  baud_rate: 0
+  level: DEBUG
+
+api:
+ota:
+web_server:
+  port: 80
+
+sensor:
+binary_sensor:
+
+climate:
+- platform: custom
+  lambda: |-
+    auto thermostat_in = new esphome::esp8266::ESP8266GPIOPin();
+    thermostat_in->set_pin(12);
+    thermostat_in->set_flags(gpio::FLAG_INPUT);
+    auto thermostat_out = new esphome::esp8266::ESP8266GPIOPin();
+    thermostat_out->set_pin(13);
+    thermostat_out->set_flags(gpio::FLAG_OUTPUT);
+    auto boiler_in = new esphome::esp8266::ESP8266GPIOPin();
+    boiler_in->set_pin(4);
+    boiler_in->set_flags(gpio::FLAG_INPUT);
+    auto boiler_out = new esphome::esp8266::ESP8266GPIOPin();
+    boiler_out->set_pin(5);
+    boiler_out->set_flags(gpio::FLAG_OUTPUT);
+    auto ot = new esphome::opentherm::OpenThermGWClimate(thermostat_in, thermostat_out, boiler_in, boiler_out);
+    App.register_component(ot);
+    ot->ch_active = new BinarySensor("CH Active");
+    App.register_binary_sensor(ot->ch_active);
+    ot->dhw_active = new BinarySensor("DHW Active");
+    App.register_binary_sensor(ot->dhw_active);
+    ot->flame_on = new BinarySensor("Flame On");
+    App.register_binary_sensor(ot->flame_on);
+    ot->diagnostic_event = new BinarySensor("Diagnostic Event");
+    App.register_binary_sensor(ot->diagnostic_event);
+    ot->fault_indication = new BinarySensor("Fault Indication");
+    App.register_binary_sensor(ot->fault_indication);
+    ot->boiler_water_temp = new Sensor("Boiler Water Temperature");
+    App.register_sensor(ot->boiler_water_temp);
+    ot->dhw_temperature = new Sensor("DHW Temperature");
+    App.register_sensor(ot->dhw_temperature);
+    ot->return_water_temperature = new Sensor("Return Water Temperature");
+    App.register_sensor(ot->return_water_temperature);
+    ot->relative_modulation_level = new Sensor("Relative Modulation Level");
+    App.register_climate(ot);
+    return {ot};
+  climates:
+    - name: "livingroom"

--- a/opentherm_gw_climate.cpp
+++ b/opentherm_gw_climate.cpp
@@ -137,11 +137,13 @@ void OpenThermGWClimate::processRequest(uint32_t request, OpenThermResponseStatu
     }
 
     uint32_t response = sOT.sendRequest(request);
-    status = sOT.getLastResponseStatus();
-    processResponse(response, status);
+    OpenThermResponseStatus resp_status = sOT.getLastResponseStatus();
+    processResponse(response, resp_status);
 
-    //ESP_LOGD(TAG, "G [%d] [%03d] [%04X]", getMessageType(response), getDataID(response), getUInt16(response));
-    mOT.sendResponse(response);
+    if (resp_status == OpenThermResponseStatus::SUCCESS) {
+      //ESP_LOGD(TAG, "G [%d] [%03d] [%04X]", getMessageType(response), getDataID(response), getUInt16(response));
+      mOT.sendResponse(response);
+    }
 }
 
 void OpenThermGWClimate::processResponse(uint32_t &response, OpenThermResponseStatus status) {
@@ -156,6 +158,9 @@ void OpenThermGWClimate::processResponse(uint32_t &response, OpenThermResponseSt
       ESP_LOGD(TAG, "ERROR, response status (%s)", statusToString(status));
       return;
     }
+
+    if (msg_type != OpenThermMessageType::READ_ACK && msg_type != OpenThermMessageType::WRITE_ACK)
+      return;
 
     switch (id) {
       case MSG_BURNER_STARTS:

--- a/opentherm_gw_climate.cpp
+++ b/opentherm_gw_climate.cpp
@@ -138,7 +138,7 @@ void OpenThermGWClimate::processRequest(uint32_t request, OpenThermResponseStatu
 
     uint32_t response = sOT.sendRequest(request);
     OpenThermResponseStatus resp_status = sOT.getLastResponseStatus();
-    processResponse(response, resp_status);
+    processResponse(request, response, resp_status);
 
     if (resp_status == OpenThermResponseStatus::SUCCESS) {
       //ESP_LOGD(TAG, "G [%d] [%03d] [%04X]", getMessageType(response), getDataID(response), getUInt16(response));
@@ -146,7 +146,7 @@ void OpenThermGWClimate::processRequest(uint32_t request, OpenThermResponseStatu
     }
 }
 
-void OpenThermGWClimate::processResponse(uint32_t &response, OpenThermResponseStatus status) {
+void OpenThermGWClimate::processResponse(uint32_t request, uint32_t &response, OpenThermResponseStatus status) {
     
     // slave/boiler response
     OpenThermMessageType msg_type = getMessageType(response);
@@ -156,6 +156,11 @@ void OpenThermGWClimate::processResponse(uint32_t &response, OpenThermResponseSt
 
     if (status != OpenThermResponseStatus::SUCCESS) {
       ESP_LOGD(TAG, "ERROR, response status (%s)", statusToString(status));
+      return;
+    }
+
+    if (id != getDataID(request)) {
+      ESP_LOGD(TAG, "ERROR, response ID doesn't match request ID");
       return;
     }
 

--- a/opentherm_gw_climate.h
+++ b/opentherm_gw_climate.h
@@ -27,7 +27,7 @@ class OpenThermGWClimate : public climate::Climate, public Component {
   climate::ClimateTraits traits() override;
 
   void processRequest(uint32_t request, OpenThermResponseStatus status);
-  void processResponse(uint32_t &response, OpenThermResponseStatus status);
+  void processResponse(uint32_t request, uint32_t &response, OpenThermResponseStatus status);
 
   void process_Master_MSG_COMMAND(uint32_t &request);
   void process_Master_MSG_DATE(uint32_t &request);


### PR DESCRIPTION
It is proposed to add separate config file template for ESP8266. In my case it was D1 mini with DIYLESS Opentherm Gateway modules.
As was correctly noted in the issue #9 , need to change gpio constructors for ESP8266 platform. But also calling of pin->pin_mode() is not suitable for this case, because later its value will be overwritten in OpenThermChannel::setup(), so need to call pin->set_flags() instead.